### PR TITLE
test: :white_check_mark: Ajuste na redefinição do bcrypt.compare no J…

### DIFF
--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -1,5 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { UsersService } from '../users/users.service';
+import { JwtService } from '@nestjs/jwt';
+import { UserTokenService } from '../user-token/user-token.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { User } from '../users/entities/user.entity';
+import { UserToken } from '../user-token/entities/userToken.entity';
+import { Repository } from 'typeorm';
 
 describe('AuthController', () => {
   let controller: AuthController;
@@ -7,6 +15,20 @@ describe('AuthController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AuthController],
+      providers: [
+        AuthService,
+        UsersService,
+        JwtService,
+        UserTokenService,
+        {
+          provide: getRepositoryToken(User),
+          useClass: Repository,
+        },
+        {
+          provide: getRepositoryToken(UserToken),
+          useClass: Repository,
+        },
+      ],
     }).compile();
 
     controller = module.get<AuthController>(AuthController);


### PR DESCRIPTION
…est usando jest.spyOn()

Estava retornando um erro causado pela tentativa de redefinir a função `compare` do `bcrypt` como um mock do Jest. Porém o `bcrypt` não permite que as funções sejam substituídas diretamente desse jeito. Por isso utilizei a função `jest.spyOn()` pra criar um espião na função `compare` e após isso defini o comportamento.